### PR TITLE
Fixed typo in script notice.blade.php, REFS issue #20

### DIFF
--- a/resources/views/notice.blade.php
+++ b/resources/views/notice.blade.php
@@ -53,7 +53,7 @@
     @if (! $hasConsented)
         window.addEventListener('load', showConsentNotice)
     @endif
-    if (hideConsentFormButton) ideConsentFormButton.addEventListener('click', hideConsentNotice)
+    if (hideConsentFormButton) hideConsentFormButton.addEventListener('click', hideConsentNotice)
     manageCookiesButton.addEventListener('click', showConsentNotice)
 </script>
 


### PR DESCRIPTION
Fixed the missing 'h' typo in notice.blade.php. This will fix the re-opening of the cookie consent modal. 