### PR TITLE
Adjust Test Workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,13 +6,23 @@ on:
 
 jobs:
   php_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        php: [8.0, 7.4, 7.3, 7.2]
+        php: [8.0, 7.4]
+        laravel: [8.*, 7.*, 6.*]
+        statamic: [3.0.*, 3.1.*]
+        os: [ubuntu-latest]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 7.*
+            testbench: 5.*
+          - laravel: 6.*
+            testbench: 4.*
 
-    name: PHP ${{ matrix.php }}
+    name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 7.3, 7.2]
+        php: [8.0, 7.4, 7.3, 7.2]
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,6 @@
 {
   "name": "doublethreedigital/cookie-notice",
-  "description": "Cookie Consent addon for Statamic.",
-  "authors": [
-    {
-      "name": "Duncan McClean",
-      "email": "duncan@doublethree.digital",
-      "homepage": "https://doublethree.digital",
-      "role": "Developer"
-    }
-  ],
+  "description": "Cookie Consent for Statamic - with support for consent groups!",
   "autoload": {
     "psr-4": {
       "DoubleThreeDigital\\CookieNotice\\": "src"
@@ -22,7 +14,7 @@
   "extra": {
     "statamic": {
       "name": "Cookie Notice",
-      "description": "Cookie Consent addon for Statamic."
+      "description": "Cookie Consent for Statamic - with support for consent groups!"
     },
     "laravel": {
       "providers": [
@@ -31,13 +23,13 @@
     }
   },
   "require": {
-    "statamic/cms": "3.0.*"
+    "php": "^7.2 || ^8.0",
+    "statamic/cms": "3.0.* || 3.1.*"
   },
   "require-dev": {
-    "orchestra/testbench": "^4.0",
+    "orchestra/testbench": "^4.0|^5.0|^6.0",
     "phpunit/phpunit": "^8.1"
   },
-  "minimum-stability": "dev",
   "scripts": {
     "lint": [
       "php-cs-fixer fix ./src"


### PR DESCRIPTION
This pull request updates the `composer.json` file to specifically specify that we support Statamic 3.0 and 3.1 and that we support anywhere from PHP 7.4, right the way up to PHP 8.

This PR also updates the testing workflow to ensure we're running the tests with all the right variants of pre-requisites that we support.