### PR TITLE
fix for when no cookie is detected

### DIFF
--- a/resources/views/notice.antlers.html
+++ b/resources/views/notice.antlers.html
@@ -106,11 +106,12 @@
             },
 
             hasConsent: function (group) {
-                if(window.cookieNotice.getCookie(COOKIE_NAME) === undefined){
-                    return false;
+                if (window.cookieNotice.getCookie(COOKIE_NAME) === undefined) {
+                    return false
                 }
-                
+
                 const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
+
                 if (group = groups.find(g => g.name === group)) {
                     return consented.includes(group.slug)
                 }

--- a/resources/views/notice.antlers.html
+++ b/resources/views/notice.antlers.html
@@ -106,6 +106,10 @@
             },
 
             hasConsent: function (group) {
+                if(window.cookieNotice.getCookie(COOKIE_NAME) === undefined){
+                    return false;
+                }
+                
                 const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
                 if (group = groups.find(g => g.name === group)) {
                     return consented.includes(group.slug)


### PR DESCRIPTION
javascript - split fails if no cookie is found in browser
