### PR TITLE
Resolve failing test suite

### DIFF
--- a/tests/Tags/CookieNoticeTagTest.php
+++ b/tests/Tags/CookieNoticeTagTest.php
@@ -39,6 +39,8 @@ class CookieNoticeTagTest extends TestCase
     /** @test */
     public function cookie_notice_tag_is_registered()
     {
+        dd($this->app['statamic.tags']);
+
         $this->assertTrue(isset($this->app['statamic.tags']['cookie_notice']));
     }
 

--- a/tests/Tags/CookieNoticeTagTest.php
+++ b/tests/Tags/CookieNoticeTagTest.php
@@ -39,8 +39,6 @@ class CookieNoticeTagTest extends TestCase
     /** @test */
     public function cookie_notice_tag_is_registered()
     {
-        dd($this->app['statamic.tags']);
-
         $this->assertTrue(isset($this->app['statamic.tags']['cookie_notice']));
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,7 +32,7 @@ abstract class TestCase extends OrchestraTestCase
         $app->make(Manifest::class)->manifest = [
             'doublethreedigital/cookie-notice' => [
                 'id' => 'doublethreedigital/cookie-notice',
-                'namespace' => 'DoubleThreeDigital\\CookieNotice\\',
+                'namespace' => 'DoubleThreeDigital\\CookieNotice',
             ],
         ];
     }


### PR DESCRIPTION
## Description

<!-- 
  What does this PR change? Has it added anything new? What has it fixed? 
  -- Maybe provide a few screenshots, a Loom (https://loom.com) or a code snippet?
-->

I noticed the other day that the test suite for this addon was failing. After a bit of digging, it turns out it was all down to the `\\` in the `TestCase` that needs removing after updating to Statamic 3.2.
