### PR TITLE
Split scripts into partial, and add separate tag to load JavaScript

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -48,17 +48,23 @@ return [
 ];
 ```
 
-* `cookie_name` defines the name of the cookie you wish to store the users' cookie preferences.
-* `groups` is an array of consent groups. Feel free to update them however you want. The key is the name of the group, which will be displayed to the user. `required` defines whether the user is absolutly required to accept cookies for that group. `toggle_by_default` will automatically check the checkbox on the consent notice, however the user will be able to uncheck it if they want.
+- `cookie_name` defines the name of the cookie you wish to store the users' cookie preferences.
+- `groups` is an array of consent groups. Feel free to update them however you want. The key is the name of the group, which will be displayed to the user. `required` defines whether the user is absolutly required to accept cookies for that group. `toggle_by_default` will automatically check the checkbox on the consent notice, however the user will be able to uncheck it if they want.
 
 ## Usage
 
 ### Displaying the cookie notice
 
-It's simple! Just add this to your site's layout (or wherever you want to put it)
+It's simple! Just add this to your site's layout:
 
-```handlebars
+```antlers
 {{ cookie_notice }}
+```
+
+If you need to move Cookie Notice's JavaScript elsewhere on the page, you can do this:
+
+```antlers
+{{ cookie_notice:scripts }}
 ```
 
 ### Overriding the cookie notice
@@ -71,15 +77,15 @@ php artisan vendor:publish --tag=cookie-notice-views
 
 The view will then be published into your `resources/views/vendor` directory. Inside the view, there's a couple of variables that are available to you:
 
-* `domain`
-* `cookie_name`
-* `groups`
-* `csrf_field`
-* `csrf_token`
-* `current_date`, `now` and `today`
-* `site` for the current site
-* `sites` for an array of all sites
-* And also any globals you have setup...
+- `domain`
+- `cookie_name`
+- `groups`
+- `csrf_field`
+- `csrf_token`
+- `current_date`, `now` and `today`
+- `site` for the current site
+- `sites` for an array of all sites
+- And also any globals you have setup...
 
 ### If user has given any consent...
 
@@ -87,7 +93,7 @@ If you want to check if the user has given consent to any of your consent groups
 
 ```js
 if (window.cookieNotice.hasConsent()) {
-    // has consented to something
+  // has consented to something
 }
 ```
 
@@ -96,7 +102,7 @@ if (window.cookieNotice.hasConsent()) {
 You'll want to make sure that you're only running marketing scripts when the user has consented to the Marketing consent group. To check if a user has consented to a particular group, do this:
 
 ```js
-if (window.cookieNotice.hasConsent('Marketing')) {
-    // marketing scripts
+if (window.cookieNotice.hasConsent("Marketing")) {
+  // marketing scripts
 }
 ```

--- a/resources/views/notice.antlers.html
+++ b/resources/views/notice.antlers.html
@@ -48,89 +48,9 @@
             Cookies</button>
     </div>
 
-    <script>
-        const cookiesForm = document.getElementById('cookiesForm')
-        const hideConsentFormButton = document.getElementById('hideConsentFormButton')
-        const manageCookiesButton = document.getElementById('manageCookiesButton')
-        const COOKIE_NAME = '{{ cookie_name }}'
-        const groups = JSON.parse('{{ groups | json }}')
-
-        window.cookieNotice = {
-            consentWithCookies: function(groups) {
-                this.setCookie(COOKIE_NAME, groups, 30)
-                this.hideConsentNotice()
-            },
-
-            showConsentNotice: function() {
-                manageCookiesButton.setAttribute('style', 'display: none;')
-                cookiesForm.removeAttribute('style')
-            },
-
-            hideConsentNotice: function() {
-                manageCookiesButton.removeAttribute('style')
-                cookiesForm.setAttribute('style', 'display: none;')
-            },
-
-            cookieExists: function(name) {
-                return document.cookie.indexOf(name + '=') !== -1
-            },
-
-            getCookie: function(name) {
-                const value = `; ${document.cookie}`
-                const parts = value.split(`; ${name}=`)
-                if (parts.length === 2) return parts.pop().split(';').shift()
-            },
-
-            setCookie: function(name, value, expirationInDays) {
-                const date = new Date()
-                date.setTime(date.getTime() + (expirationInDays * 24 * 60 * 60 * 1000))
-
-                document.cookie = name + '=' + value +
-                    ';expires=' + date.toUTCString() +
-                    ';domain={{ domain }}' +
-                    ';path=/{{ config:session:secure ? ';secure' : null }}' +
-                    '{{ if config:session:same_site }};samesite={{ config:session:same_site }}{{ /if }}'
-            },
-
-            hasConsent: function(group) {
-                if (window.cookieNotice.getCookie(COOKIE_NAME) === undefined) {
-                    return false
-                }
-
-                const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
-
-                if (group = groups.find(g => g.name === group)) {
-                    return consented.includes(group.slug)
-                }
-
-                return consented.length > 0
-            }
-        }
-
-        cookiesForm.addEventListener('submit', function(event) {
-            event.preventDefault()
-            const formData = new FormData(event.target)
-            const groups = formData.getAll('groups')
-
-            window.cookieNotice.consentWithCookies(groups)
-        })
-
-        window.addEventListener('load', function() {
-            if (!window.cookieNotice.cookieExists(COOKIE_NAME)) {
-                window.cookieNotice.showConsentNotice()
-                hideConsentFormButton.setAttribute('style', 'display: none;')
-            } else {
-                const groups = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
-
-                for (let i = 0; i < groups.length; i++) {
-                    document.getElementById(groups[i]).setAttribute('checked', true)
-                }
-            }
-        })
-
-        hideConsentFormButton.addEventListener('click', window.cookieNotice.hideConsentNotice)
-        manageCookiesButton.addEventListener('click', window.cookieNotice.showConsentNotice)
-    </script>
+    {{ if !already_rendered_scripts }}
+        {{ partial src="cookie-notice::scripts" }}
+    {{ /if }}
 
     <link rel="stylesheet" href="/vendor/cookie-notice/css/cookie-notice.css">
 {{ /if }}

--- a/resources/views/notice.antlers.html
+++ b/resources/views/notice.antlers.html
@@ -1,18 +1,12 @@
 {{ if !live_preview }}
     <div class="cookies-fixed cookies-bottom-0 md:cookies-right-0" style="z-index: 999;">
-        <form
-            id="cookiesForm"
+        <form id="cookiesForm"
             class="cookies-bg-white cookies-rounded-lg cookies-mx-6 cookies-my-6 cookies-p-6 md:cookies-w-1/3 cookies-float-right cookies-text-gray-800"
-            method="POST"
-            style="display: none"
-        >
-            <h2
-                class="cookies-font-semibold cookies-text-2xl cookies-mb-1"
-            >This site uses cookies</h2>
+            method="POST" style="display: none">
+            <h2 class="cookies-font-semibold cookies-text-2xl cookies-mb-1">This site uses cookies</h2>
 
-            <p
-                class="cookies-text-sm"
-            >We use cookies on this site so we can provide you with personalised content, ads and to analyse our website's traffic. By continuing to use this website, you consent to cookies.</p>
+            <p class="cookies-text-sm">We use cookies on this site so we can provide you with personalised content, ads
+                and to analyse our website's traffic. By continuing to use this website, you consent to cookies.</p>
 
             {{ csrf_field }}
 
@@ -20,17 +14,14 @@
                 {{ foreach:groups as="group" }}
                     {{ group }}
                         <label class="cookies-mb-1" for="{{ slug }}">
-                            <input
-                                id="{{ slug }}"
-                                type="checkbox"
-                                name="groups"
+                            <input id="{{ slug }}" type="checkbox" name="groups"
                                 value="{{ slug }}"
                                 {{ if toggle_by_default && !cookie || required }}
-                                    checked
+                            checked
                                 {{ /if }}
-                                {{ if required }}
-                                    required onclick="this.checked = true"
-                                {{ /if }}
+                            {{ if required }}
+                                required onclick="this.checked = true"
+                            {{ /if }}
                             >
                             {{ name }}
                             {{ if required }}
@@ -44,21 +35,17 @@
             <div class="cookies-flex cookies-flex-row cookies-items-center">
                 <button
                     class="cookies-bg-blue-500 hover:cookies-bg-blue-600 cookies-rounded cookies-text-center cookies-text-white cookies-px-6 cookies-py-2 focus:cookies-outline-none cookies-cursor-pointer"
-                    type="submit"
-                >Accept</button>
+                    type="submit">Accept</button>
 
-                <button
-                    id="hideConsentFormButton"
+                <button id="hideConsentFormButton"
                     class="cookies-ml-4 cookies-text-gray-800 cookies-text-sm focus:cookies-outline-none cookies-cursor-pointer cookies-bg-white"
-                    type="button"
-                >Hide</button>
+                    type="button">Hide</button>
             </div>
         </form>
 
-        <button
-            id="manageCookiesButton"
-            class="cookies-bg-white cookies-rounded-lg cookies-mr-2 cookies-mb-2 cookies-p-2 cookies-float-right focus:cookies-outline-none cookies-cursor-pointer"
-        >Manage Cookies</button>
+        <button id="manageCookiesButton"
+            class="cookies-bg-white cookies-rounded-lg cookies-mr-2 cookies-mb-2 cookies-p-2 cookies-float-right focus:cookies-outline-none cookies-cursor-pointer">Manage
+            Cookies</button>
     </div>
 
     <script>
@@ -69,7 +56,7 @@
         const groups = JSON.parse('{{ groups | json }}')
 
         window.cookieNotice = {
-            consentWithCookies: function (groups) {
+            consentWithCookies: function(groups) {
                 this.setCookie(COOKIE_NAME, groups, 30)
                 this.hideConsentNotice()
             },
@@ -98,14 +85,14 @@
                 const date = new Date()
                 date.setTime(date.getTime() + (expirationInDays * 24 * 60 * 60 * 1000))
 
-                document.cookie = name + '=' + value
-                    + ';expires=' + date.toUTCString()
-                    + ';domain={{ domain }}'
-                    + ';path=/{{ config:session:secure ? ';secure' : null }}'
-                    + '{{ if config:session:same_site }};samesite={{ config:session:same_site }}{{ /if }}'
+                document.cookie = name + '=' + value +
+                    ';expires=' + date.toUTCString() +
+                    ';domain={{ domain }}' +
+                    ';path=/{{ config:session:secure ? ';secure' : null }}' +
+                    '{{ if config:session:same_site }};samesite={{ config:session:same_site }}{{ /if }}'
             },
 
-            hasConsent: function (group) {
+            hasConsent: function(group) {
                 if (window.cookieNotice.getCookie(COOKIE_NAME) === undefined) {
                     return false
                 }
@@ -120,7 +107,7 @@
             }
         }
 
-        cookiesForm.addEventListener('submit', function (event) {
+        cookiesForm.addEventListener('submit', function(event) {
             event.preventDefault()
             const formData = new FormData(event.target)
             const groups = formData.getAll('groups')
@@ -128,8 +115,8 @@
             window.cookieNotice.consentWithCookies(groups)
         })
 
-        window.addEventListener('load', function () {
-            if (! window.cookieNotice.cookieExists(COOKIE_NAME)) {
+        window.addEventListener('load', function() {
+            if (!window.cookieNotice.cookieExists(COOKIE_NAME)) {
                 window.cookieNotice.showConsentNotice()
                 hideConsentFormButton.setAttribute('style', 'display: none;')
             } else {

--- a/resources/views/scripts.antlers.html
+++ b/resources/views/scripts.antlers.html
@@ -1,0 +1,99 @@
+<!-- Start: Cookie Notice scripts -->
+<script>
+    let cookiesForm = document.getElementById('cookiesForm')
+    let hideConsentFormButton = document.getElementById('hideConsentFormButton')
+    let manageCookiesButton = document.getElementById('manageCookiesButton')
+    let COOKIE_NAME = '{{ cookie_name }}'
+    let groups = JSON.parse('{{ groups | json }}')
+
+    window.cookieNotice = {
+        consentWithCookies: function(groups) {
+            this.setCookie(COOKIE_NAME, groups, 30)
+            this.hideConsentNotice()
+        },
+
+        showConsentNotice: function() {
+            manageCookiesButton.setAttribute('style', 'display: none;')
+            cookiesForm.removeAttribute('style')
+        },
+
+        hideConsentNotice: function() {
+            manageCookiesButton.removeAttribute('style')
+            cookiesForm.setAttribute('style', 'display: none;')
+        },
+
+        cookieExists: function(name) {
+            return document.cookie.indexOf(name + '=') !== -1
+        },
+
+        getCookie: function(name) {
+            const value = `; ${document.cookie}`
+            const parts = value.split(`; ${name}=`)
+            if (parts.length === 2) return parts.pop().split(';').shift()
+        },
+
+        setCookie: function(name, value, expirationInDays) {
+            const date = new Date()
+            date.setTime(date.getTime() + (expirationInDays * 24 * 60 * 60 * 1000))
+
+            document.cookie = name + '=' + value +
+                ';expires=' + date.toUTCString() +
+                ';domain={{ domain }}' +
+                ';path=/{{ config:session:secure ? ';secure' : null }}' +
+                '{{ if config:session:same_site }};samesite={{ config:session:same_site }}{{ /if }}'
+        },
+
+        hasConsent: function(group) {
+            if (window.cookieNotice.getCookie(COOKIE_NAME) === undefined) {
+                return false
+            }
+
+            const consented = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
+
+            if (group = groups.find(g => g.name === group)) {
+                return consented.includes(group.slug)
+            }
+
+            return consented.length > 0
+        }
+    }
+
+    window.addEventListener('load', function() {
+        cookiesForm = document.getElementById('cookiesForm')
+        hideConsentFormButton = document.getElementById('hideConsentFormButton')
+        manageCookiesButton = document.getElementById('manageCookiesButton')
+        COOKIE_NAME = '{{ cookie_name }}'
+        groups = JSON.parse('{{ groups | json }}')
+
+        cookiesForm.addEventListener('submit', function(event) {
+            event.preventDefault()
+            const formData = new FormData(event.target)
+            const groups = formData.getAll('groups')
+
+            window.cookieNotice.consentWithCookies(groups)
+        })
+
+        cookiesForm.addEventListener('submit', function(event) {
+            event.preventDefault()
+            const formData = new FormData(event.target)
+            const groups = formData.getAll('groups')
+
+            window.cookieNotice.consentWithCookies(groups)
+        })
+
+        if (!window.cookieNotice.cookieExists(COOKIE_NAME)) {
+            window.cookieNotice.showConsentNotice()
+            hideConsentFormButton.setAttribute('style', 'display: none;')
+        } else {
+            const groups = window.cookieNotice.getCookie(COOKIE_NAME).split(',')
+
+            for (let i = 0; i < groups.length; i++) {
+                document.getElementById(groups[i]).setAttribute('checked', true)
+            }
+        }
+
+        hideConsentFormButton.addEventListener('click', window.cookieNotice.hideConsentNotice)
+        manageCookiesButton.addEventListener('click', window.cookieNotice.showConsentNotice)
+    })
+</script>
+<!-- End: Cookie Notice scripts -->

--- a/resources/views/scripts.antlers.html
+++ b/resources/views/scripts.antlers.html
@@ -62,8 +62,6 @@
         cookiesForm = document.getElementById('cookiesForm')
         hideConsentFormButton = document.getElementById('hideConsentFormButton')
         manageCookiesButton = document.getElementById('manageCookiesButton')
-        COOKIE_NAME = '{{ cookie_name }}'
-        groups = JSON.parse('{{ groups | json }}')
 
         cookiesForm.addEventListener('submit', function(event) {
             event.preventDefault()

--- a/src/Tags/CookieNoticeTag.php
+++ b/src/Tags/CookieNoticeTag.php
@@ -9,20 +9,20 @@ use Statamic\Tags\Tags;
 
 class CookieNoticeTag extends Tags
 {
+    public static $alreadyRenderedScripts = false;
+
     protected static $handle = 'cookie_notice';
 
     public function index()
     {
-        $viewData = array_merge($this->gatherData(), [
-            'domain' => config('session.domain') ?? request()->getHost(),
-            'cookie_name'   => config('cookie-notice.cookie_name'),
-            'groups'        => $this->groups(),
-        ]);
+        return view('cookie-notice::notice', $this->viewData());
+    }
 
-        return view(
-            'cookie-notice::notice',
-            $viewData
-        );
+    public function scripts()
+    {
+        static::$alreadyRenderedScripts = true;
+
+        return view('cookie-notice::scripts', $this->viewData());
     }
 
     protected function groups(): array
@@ -38,9 +38,10 @@ class CookieNoticeTag extends Tags
             ->toArray();
     }
 
-    protected function gatherData(): array
+    protected function viewData(): array
     {
         $array = [
+            // Some Statamic-y variables
             'csrf_field' => csrf_field(),
             'csrf_token' => csrf_token(),
 
@@ -50,6 +51,12 @@ class CookieNoticeTag extends Tags
 
             'site' => Site::current(),
             'sites' => Site::all()->values(),
+
+            // Cookie Notice variables
+            'domain'        => config('session.domain') ?? request()->getHost(),
+            'cookie_name'   => config('cookie-notice.cookie_name'),
+            'groups'        => $this->groups(),
+            'already_rendered_scripts' => static::$alreadyRenderedScripts,
         ];
 
         foreach (GlobalSet::all() as $global) {


### PR DESCRIPTION
There's sometimes cases where you may wish to load in the JavaScript for the cookie notice in a different place than the notice itself.

You can now use the `scripts` method on the tag to do this:

```antlers
{{ cookie-notice:scripts }}
```

This should solve issues like #48.