### PR TITLE
Statamic 3.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         php: [8.0, 7.4]
         laravel: [8.*, 7.*, 6.*]
-        statamic: [3.0.*, 3.1.*, 3.2.*]
+        statamic: [3.2.*, 3.3.*]
         os: [ubuntu-latest]
         include:
           - laravel: 8.*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,11 +37,11 @@ jobs:
       #   run: rm composer.lock
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extension-csv: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
-          coverage: none
+          tools: composer:v2
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
 
-      - name: Delete composer.lock
-        run: rm composer.lock
+      # - name: Delete composer.lock
+      #   run: rm composer.lock
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,23 +10,31 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0, 7.4]
-        laravel: [8.*, 7.*, 6.*]
-        statamic: [3.2.*, 3.3.*]
+        php: [8.1, 8.0, 7.4]
+        laravel: [9.*, 8.*]
+        statamic: [^3.2, ^3.3]
         os: [ubuntu-latest]
         include:
+          - laravel: 9.*
+            framework: ^9.1.0
+            testbench: 7.*
           - laravel: 8.*
+            framework: ^8.24.0
             testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
-          - laravel: 6.*
-            testbench: 4.*
+        exclude:
+          - laravel: 9.*
+            statamic: ^3.2
+          - laravel: 9.*
+            php: 7.4
 
     name: ${{ matrix.php }} - ${{ matrix.statamic }} - ${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v1
+
+      - name: Delete composer.lock
+        run: rm composer.lock
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v1
@@ -37,7 +45,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer validate
+          composer require "laravel/framework:${{ matrix.laravel }}" "statamic/cms:${{ matrix.statamic }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer install --no-interaction
 
       - name: Run PHPUnit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v5.1.0 (2022-02-26)
+
+### What's new
+
+- Statamic 3.3 support
+
+### Breaking changes
+
+- Dropped support for Statamic 3.0 and Statamic 3.1
+
 ## v5.0.8 (2022-01-22)
 
 ### What's new

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
         }
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0 || ^8.1",
         "pixelfear/composer-dist-plugin": "^0.1.5",
         "statamic/cms": "3.2.* || 3.3.*"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0",
         "phpunit/phpunit": "^8.1"
     },
     "scripts": {
@@ -51,5 +51,6 @@
         "allow-plugins": {
             "pixelfear/composer-dist-plugin": true
         }
-    }
+    },
+    "minimum-stability": "beta"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,52 +1,55 @@
 {
-  "name": "doublethreedigital/cookie-notice",
-  "description": "Cookie Consent for Statamic - with support for consent groups!",
-  "license": "proprietary",
-  "autoload": {
-    "psr-4": {
-      "DoubleThreeDigital\\CookieNotice\\": "src"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "DoubleThreeDigital\\CookieNotice\\Tests\\": "tests"
-    }
-  },
-  "extra": {
-    "download-dist": {
-        "url": "https://github.com/doublethreedigital/cookie-notice/releases/download/{$version}/dist.tar.gz",
-        "path": "resources/dist"
+    "name": "doublethreedigital/cookie-notice",
+    "description": "Cookie Consent for Statamic - with support for consent groups!",
+    "license": "proprietary",
+    "autoload": {
+        "psr-4": {
+            "DoubleThreeDigital\\CookieNotice\\": "src"
+        }
     },
-    "statamic": {
-      "name": "Cookie Notice",
-      "description": "Cookie Consent for Statamic - with support for consent groups!"
+    "autoload-dev": {
+        "psr-4": {
+            "DoubleThreeDigital\\CookieNotice\\Tests\\": "tests"
+        }
     },
-    "laravel": {
-      "providers": [
-        "DoubleThreeDigital\\CookieNotice\\ServiceProvider"
-      ]
+    "extra": {
+        "download-dist": {
+            "url": "https://github.com/doublethreedigital/cookie-notice/releases/download/{$version}/dist.tar.gz",
+            "path": "resources/dist"
+        },
+        "statamic": {
+            "name": "Cookie Notice",
+            "description": "Cookie Consent for Statamic - with support for consent groups!"
+        },
+        "laravel": {
+            "providers": [
+                "DoubleThreeDigital\\CookieNotice\\ServiceProvider"
+            ]
+        }
+    },
+    "require": {
+        "php": "^7.2 || ^8.0",
+        "pixelfear/composer-dist-plugin": "^0.1.5",
+        "statamic/cms": "3.2.* || 3.3.*"
+    },
+    "require-dev": {
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "phpunit/phpunit": "^8.1"
+    },
+    "scripts": {
+        "lint": [
+            "php-cs-fixer fix ./src"
+        ],
+        "test": [
+            "./vendor/bin/phpunit"
+        ]
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true,
+        "allow-plugins": {
+            "pixelfear/composer-dist-plugin": true
+        }
     }
-  },
-  "require": {
-    "php": "^7.2 || ^8.0",
-    "pixelfear/composer-dist-plugin": "^0.1.5",
-    "statamic/cms": "3.0.* || 3.1.* || 3.2.*"
-  },
-  "require-dev": {
-    "orchestra/testbench": "^4.0|^5.0|^6.0",
-    "phpunit/phpunit": "^8.1"
-  },
-  "scripts": {
-    "lint": [
-      "php-cs-fixer fix ./src"
-    ],
-    "test": [
-      "./vendor/bin/phpunit"
-    ]
-  },
-  "config": {
-    "optimize-autoloader": true,
-    "preferred-install": "dist",
-    "sort-packages": true
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,8 +33,7 @@
         "statamic/cms": "3.2.* || 3.3.*"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0",
-        "phpunit/phpunit": "^8.1"
+        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0"
     },
     "scripts": {
         "lint": [


### PR DESCRIPTION
This pull request introduces compatibility for Statamic 3.3 which is due to be released within the next few days.

This PR also drops support for Statamic 3.0 and 3.1. Statamic 3.2 and above are now the supported versions.

**Note:** the tests will be failing until Statamic 3.3 has been tagged.