### PR TITLE
Supports Laravel 13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php: [8.3, 8.4, 8.5]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require": {
         "php": "^8.3",
         "pixelfear/composer-dist-plugin": "^0.1.5",
-        "statamic/cms": "^6.3"
+        "statamic/cms": "^6.5"
     },
     "require-dev": {
         "laravel/pint": "dev-main",

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
     },
     "require-dev": {
         "laravel/pint": "dev-main",
-        "orchestra/testbench": "^10.8",
+        "orchestra/testbench": "^10.8 || ^11.0",
         "pestphp/pest": "^3.0 || ^4.1",
         "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
-        "spatie/laravel-ray": "^1.43"
+        "spatie/laravel-ray": "^1.43.6"
     },
     "config": {
         "optimize-autoloader": true,
@@ -47,5 +47,7 @@
             "pixelfear/composer-dist-plugin": true,
             "pestphp/pest-plugin": true
         }
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
This pull request adds Laravel 13 support to Cookie Notice. Laravel 13 is due to be released [Early March](https://x.com/taylorotwell/status/2021555106269831216).

Depends on:
* [x] https://github.com/statamic/cms/pull/13870